### PR TITLE
Fix spacescan API 404 error

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -5,7 +5,7 @@ const config = {
     GET_TAIL_URL: process.env.REACT_APP_GET_TAIL_URL || '',
     GET_TAILS_URL: process.env.REACT_APP_GET_TAILS_URL || '',
     GET_SEARCH_INDEX_URL: process.env.REACT_APP_GET_SEARCH_INDEX_URL || '',
-    SPACESCAN_CAT_URL: process.env.REACT_APP_SPACESCAN_CAT_URL || 'https://api-fin.spacescan.io/cat/transactions/',
+    SPACESCAN_CAT_URL: process.env.REACT_APP_SPACESCAN_CAT_URL || 'https://api-fin.spacescan.io/cat/transactions',
     REVEAL_URL: process.env.REACT_APP_REVEAL_URL || 'https://mainnet-api.taildatabase.com/reveal',
 };
 


### PR DESCRIPTION
I fixed error that caused 404 error during spacescan API request. Also the API for adding tail and for reveal not working.