### PR TITLE
remove tailing slash on SPACESCAN_CAT_URL since its added in the url later

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -5,7 +5,7 @@ const config = {
     GET_TAIL_URL: process.env.REACT_APP_GET_TAIL_URL || '',
     GET_TAILS_URL: process.env.REACT_APP_GET_TAILS_URL || '',
     GET_SEARCH_INDEX_URL: process.env.REACT_APP_GET_SEARCH_INDEX_URL || '',
-    SPACESCAN_CAT_URL: process.env.REACT_APP_SPACESCAN_CAT_URL || 'https://api-fin.spacescan.io/cat/transactions/',
+    SPACESCAN_CAT_URL: process.env.REACT_APP_SPACESCAN_CAT_URL || 'https://api-fin.spacescan.io/cat/transactions',
     REVEAL_URL: process.env.REACT_APP_REVEAL_URL || 'https://mainnet-api.taildatabase.com/reveal',
 };
 


### PR DESCRIPTION
The slash added here https://github.com/Tail-Database/tail-database-ui/blob/97b170b5e58752617e294ee90e954591311a2aba/src/pages/AddTail/AddTail.tsx#L34 was resulting in a double slash, which caused a 404 on the API and breaks looking up the coin id